### PR TITLE
Don't try to reconcile CSV with API

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -11,45 +11,13 @@ require 'scraperwiki'
 require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
 
-def json_from(url)
-  JSON.parse(open(url).read, symbolize_names: true)
-end
-
-@POPONG_API = 'http://api.popong.com/v0.1/person/search?q=%s&api_key=test'
-
-def find_popong(row)
-  search = json_from(@POPONG_API % URI::encode(row[:name_kr])) 
-  return {} if search[:items].count.zero?
-  return search[:items].first if search[:items].count == 1
-
-  if (addressed = search[:items].find_all { |i| i[:address] }).size == 1
-    # warn "Found by address".cyan
-    return addressed.first
-  end
-
-  first_unique = ->(json_sym, csv_sym) { 
-    filtered = search[:items].find_all { |s| s[json_sym] = row[csv_sym] }
-    return filtered.first if filtered.size == 1
-  }
-
-  return first_unique.(:name_en, :name_en) || first_unique.(:name_cn, :name_cn) || first_unique.(:birthday, :birth) 
-  # || search[:items].sort_by { |i| i.reject { |k,v| v.to_s.empty? }.keys.count }.last
-end
-
-
 file = 'https://raw.githubusercontent.com/teampopong/data-assembly/master/assembly.csv'
 raw = open(file).read
 
 csv = CSV.parse(raw, headers: true, header_converters: :symbol)
 csv.each do |row|
-  json = find_popong(row) || begin
-    warn "No match for #{row[:name_en]}".red
-    {}
-  end
-
-  data = { 
-    id: json[:id] || row[:name_en].downcase.tr(' ','-'),
-    identifier__popong: json[:id],
+  data = {
+    id: row[:name_en].downcase.tr(' ','-'),
     name: row[:name_en].strip,
     name__ko: row[:name_kr],
     name__cn: row[:name_cn],
@@ -61,14 +29,8 @@ csv.each do |row|
     email: row[:email],
     photo: row[:photo],
     term: 20,
-    source: "github.com/teampopong/data-for-rnd",
-
-    wikipedia: json[:wiki],
-    twitter: json[:twitter],
-    facebook: json[:facebook],
+    source: 'https://github.com/teampopong/data-assembly',
   }
 
   ScraperWiki.save_sqlite([:id, :name, :term], data)
 end
-
-


### PR DESCRIPTION
Trying to match the CSV with the API is a bit haphazard and is probably better done as part of the reconciliation process in the everypolitician-data process. This change removes the API matching and just sucks in the CSV from the data-assembly repo.

Part of https://github.com/everypolitician/everypolitician-data/issues/14151
